### PR TITLE
fix: ruby2_keywords warning

### DIFF
--- a/lib/faraday/xml/response.rb
+++ b/lib/faraday/xml/response.rb
@@ -10,7 +10,6 @@ module Faraday
         @content_types = Array(options.fetch(:content_type, /\bxml$/))
         @preserve_raw = options.fetch(:preserve_raw, false)
       end
-      ruby2_keywords :initialize if respond_to?(:ruby2_keywords, true)
 
       # @param env [Faraday::Env] the environment of the response being processed.
       def on_complete(env)


### PR DESCRIPTION
faraday-xml-0.1.0/lib/faraday/xml/response.rb:13
warning: Skipping set of ruby2_keywords flag for initialize
(method accepts keywords or method does not accept argument splat)