### PR TITLE
Add Ruby 4.0 support, drop EOL Ruby versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,11 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: '3.4'
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop
@@ -26,10 +26,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '3.2', '3.3', '3.4', '4.0' ]
         faraday: [ '~> 1.0', '~> 2.0' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 require:
   - rubocop-packaging
+
+plugins:
   - rubocop-performance
   - rubocop-rspec
 
@@ -11,7 +13,7 @@ inherit_mode:
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.2
   SuggestExtensions: false
   NewCops: enable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 # Changelog
 
-## [Unreleased](https://github.com/gemhome/faraday-xml/compare/v0.2.1...main)
+## [0.3.0](https://github.com/gemhome/faraday-xml/compare/v0.2.1...v0.3.0) (2025-12-26)
+
+- **BREAKING:** Drop support for Ruby < 3.2 (EOL versions)
+- feat: Add support for Ruby 4.0
+- chore: Update development dependencies to latest versions
+- chore: Update CI matrix to test Ruby 3.2, 3.3, 3.4, and 4.0
 
 ## [0.2.1](https://github.com/gemhome/faraday-xml/compare/v0.2.0...v0.2.1)
 
-*   feat: extract Faraday::XML::Encoder
-*   feat: extract Faraday::XML::Parser
+- feat: extract Faraday::XML::Encoder
+- feat: extract Faraday::XML::Parser
 
 ## [0.2.0](https://github.com/gemhome/faraday-xml/compare/v0.1.0...v0.2.0)
 
-*   feat: simple Hash -> XML request encoder
+- feat: simple Hash -> XML request encoder
 
 ## [0.1.0](https://github.com/gemhome/faraday-xml/blob/v0.1.0) (2023-01-12)
 
-*   feat: Initial release.
+- feat: Initial release.

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,18 @@ gemspec
 install_if -> { ENV.fetch('FARADAY_VERSION', nil) } do
   gem 'faraday', ENV.fetch('FARADAY_VERSION', nil)
 end
+
 gem 'activesupport'
 gem 'builder'
+gem 'rexml' # Required for Ruby 3.4+ (no longer in stdlib)
+
+group :development do
+  gem 'bundler', '~> 2.4'
+  gem 'rake', '~> 13.0'
+  gem 'rspec', '~> 3.13'
+  gem 'rubocop', '~> 1.69'
+  gem 'rubocop-packaging', '~> 0.5.2'
+  gem 'rubocop-performance', '~> 1.23'
+  gem 'rubocop-rspec', '~> 3.3'
+  gem 'simplecov', '~> 0.22.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -17,12 +17,8 @@ gem 'builder'
 gem 'rexml' # Required for Ruby 3.4+ (no longer in stdlib)
 
 group :development do
-  gem 'bundler', '~> 2.4'
-  gem 'rake', '~> 13.0'
-  gem 'rspec', '~> 3.13'
   gem 'rubocop', '~> 1.69'
   gem 'rubocop-packaging', '~> 0.5.2'
   gem 'rubocop-performance', '~> 1.23'
   gem 'rubocop-rspec', '~> 3.3'
-  gem 'simplecov', '~> 0.22.0'
 end

--- a/faraday-xml.gemspec
+++ b/faraday-xml.gemspec
@@ -30,17 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 2.6', '< 4'
+  spec.required_ruby_version = '>= 3.2', '< 5'
 
-  spec.add_runtime_dependency 'faraday', '>= 1.10', '< 3'
-
-  spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'simplecov', '~> 0.21.0'
-
-  spec.add_development_dependency 'rubocop', '~> 1.31.0'
-  spec.add_development_dependency 'rubocop-packaging', '~> 0.5.0'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.0'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.0'
+  spec.add_dependency 'faraday', '>= 1.10', '< 3'
 end

--- a/faraday-xml.gemspec
+++ b/faraday-xml.gemspec
@@ -33,4 +33,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency 'faraday', '>= 1.10', '< 3'
+
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'simplecov', '~> 0.22.0'
 end

--- a/faraday-xml.gemspec
+++ b/faraday-xml.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 3.2', '< 5'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency 'faraday', '>= 1.10', '< 3'
 end

--- a/lib/faraday/xml/request.rb
+++ b/lib/faraday/xml/request.rb
@@ -13,7 +13,7 @@ module Faraday
     # Doesn't try to encode bodies that already are in string form.
     class Request < Middleware
       MIME_TYPE = 'application/xml'
-      MIME_TYPE_REGEX = %r{^application/(vnd\..+\+)?xml$}.freeze
+      MIME_TYPE_REGEX = %r{^application/(vnd\..+\+)?xml$}
 
       def initialize(app = nil, options = {})
         super(app)

--- a/lib/faraday/xml/version.rb
+++ b/lib/faraday/xml/version.rb
@@ -2,6 +2,6 @@
 
 module Faraday
   module XML
-    VERSION = '0.2.1'
+    VERSION = '0.3.0'
   end
 end


### PR DESCRIPTION
### Changes
- Require Ruby >= 3.2, < 5 (drops EOL versions 2.6–3.1)
- Add Ruby 4.0 to CI matrix
- Add `rexml` dependency (extracted from stdlib in Ruby 3.4+)
- Move dev dependencies to Gemfile per modern conventions
- Update rubocop to use plugin syntax where supported
- Bump to v0.3.0

### CI Matrix
Ruby: 3.2, 3.3, 3.4, 4.0
Faraday: 1.x, 2.x